### PR TITLE
Return total_count for area types

### DIFF
--- a/features/area-types.authorised.feature
+++ b/features/area-types.authorised.feature
@@ -72,11 +72,13 @@ Feature: Area Types Private Endpoints Enabled
         "area-types": [
           {
             "id": "country",
-            "label": "Country"
+            "label": "Country",
+            "total_count": 2
           },
           {
             "id": "city",
-            "label": "City"
+            "label": "City",
+            "total_count": 3
           }
         ]
       }

--- a/features/area-types.feature
+++ b/features/area-types.feature
@@ -67,11 +67,13 @@ Feature: Area Types
         "area-types":[
           {
             "id":"country",
-            "label":"Country"
+            "label":"Country",
+            "total_count": 2
           },
           {
             "id":"city",
-            "label":"City"
+            "label":"City",
+            "total_count": 3
           }
         ]
       }
@@ -139,11 +141,13 @@ Feature: Area Types
         "area-types":[
           {
             "id":"country",
-            "label":"Country"
+            "label":"Country",
+            "total_count": 2
           },
           {
             "id":"city",
-            "label":"City"
+            "label":"City",
+            "total_count": 3
           }
         ]
       }

--- a/handler/area_types.go
+++ b/handler/area_types.go
@@ -57,8 +57,9 @@ func (h *AreaTypes) Get(w http.ResponseWriter, r *http.Request) {
 	if res != nil {
 		for _, edge := range res.Dataset.RuleBase.IsSourceOf.Edges {
 			resp.AreaTypes = append(resp.AreaTypes, model.AreaType{
-				ID:    edge.Node.Name,
-				Label: edge.Node.Label,
+				ID:         edge.Node.Name,
+				Label:      edge.Node.Label,
+				TotalCount: edge.Node.Categories.TotalCount,
 			})
 		}
 	}

--- a/model/area_types.go
+++ b/model/area_types.go
@@ -2,6 +2,7 @@ package model
 
 // AreaType is an area-type model with ID and Label
 type AreaType struct {
-	ID    string `json:"id"`
-	Label string `json:"label"`
+	ID         string `json:"id"`
+	Label      string `json:"label"`
+	TotalCount int    `json:"total_count"`
 }


### PR DESCRIPTION
### What

Exposes the `total_count` property on the `area-types` endpoint.
[https://trello.com/c/zTCBdNhM/5620-add-total-count-to-the-get-area-types-endpoint](https://trello.com/c/zTCBdNhM/5620-add-total-count-to-the-get-area-types-endpoint)

#### Context
This is to enable the area selection radio buttons to display the count in the label.
[https://trello.com/c/yOjZDYAj/5569-create-front-end-to-display-list-of-area-types](https://trello.com/c/yOjZDYAj/5569-create-front-end-to-display-list-of-area-types)

### How to review

Check the code and test the API returns the value.

### Who can review

Anyone.
