### PR TITLE
Fix Cantabular EXT API environment variable name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	HealthCheckCriticalTimeout   time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	ZebedeeURL                   string        `envconfig:"ZEBEDEE_URL"`
 	CantabularURL                string        `envconfig:"CANTABULAR_URL"`
-	CantabularExtURL             string        `envconfig:"CANTABULAR_EXT_API_URL"`
+	CantabularExtURL             string        `envconfig:"CANTABULAR_API_EXT_URL"`
 	ComponentTestUseLogFile      bool          `envconfig:"COMPONENT_TEST_USE_LOG_FILE"`
 	EnablePrivateEndpoints       bool          `envconfig:"ENABLE_PRIVATE_ENDPOINTS"`
 	EnablePermissionsAuth        bool          `envconfig:"ENABLE_PERMISSIONS_AUTH"`


### PR DESCRIPTION
### What

Updated to match [`dp-config`](https://github.com/ONSdigital/dp-configs/commit/6ad650f161cfb28c596527cc5b6861987d536ec1) and other services (e.g. filter flex).

### How to review

Confirm the var matches that in `dp-config`.

### Who can review

Anyone.
